### PR TITLE
Add RSS feed support for published blog posts

### DIFF
--- a/app/blog/constants.py
+++ b/app/blog/constants.py
@@ -2,3 +2,8 @@ BLOG_META_DESCRIPTION = (
     "This is my personal blog. I write about coding with python, Django and "
     "other tech stuff. My opinions are my own."
 )
+
+BLOG_TITLE = "Abel Castro Blog"
+
+# The blog frontend is served from this domain (see the redirect views).
+BLOG_DOMAIN = "https://blog.abelcastro.dev"

--- a/app/blog/feeds.py
+++ b/app/blog/feeds.py
@@ -1,0 +1,36 @@
+import datetime
+
+from blog.constants import BLOG_DOMAIN, BLOG_META_DESCRIPTION, BLOG_TITLE
+from blog.models import Post
+from django.contrib.syndication.views import Feed
+from django.utils import timezone
+from martor.utils import markdownify
+
+
+class LatestPostsFeed(Feed):
+    title = BLOG_TITLE
+    description = BLOG_META_DESCRIPTION
+    author_name = "Abel Castro"
+    link = f"{BLOG_DOMAIN}/"
+
+    def items(self):
+        return Post.objects.filter(published=True).prefetch_related("tags")[:20]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        return markdownify(item.content)
+
+    def item_link(self, item):
+        return f"{BLOG_DOMAIN}/{item.slug}/"
+
+    def item_pubdate(self, item):
+        if not item.date:
+            return None
+        return timezone.make_aware(
+            datetime.datetime.combine(item.date, datetime.time.min)
+        )
+
+    def item_categories(self, item):
+        return [tag.name for tag in item.tags.all()]

--- a/app/blog/tests.py
+++ b/app/blog/tests.py
@@ -36,3 +36,42 @@ def test__no_n_plus_one(client, django_assert_max_num_queries):
     with django_assert_max_num_queries(5):
         response = client.get("/")
         assert response.status_code == 200
+
+
+@mark.django_db
+def test__rss_feed(client):
+    """
+    The RSS feed lists published posts and links to the live blog domain.
+    """
+    import datetime
+
+    tag = Tag.objects.create(name="Syndication")
+    published = Post.objects.create(
+        title="My RSS post",
+        slug="my-rss-post",
+        meta_description="a post that shows up in the feed",
+        content="# Heading\n\nSome **content**.",
+        published=True,
+    )
+    published.tags.add(tag)
+
+    Post.objects.create(
+        title="Draft post",
+        slug="draft-post",
+        meta_description="a draft that must stay hidden",
+        content="secret draft",
+        published=False,
+        date=datetime.date(2024, 1, 1),
+    )
+
+    response = client.get("/feed/")
+
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("application/rss+xml")
+
+    content = response.content.decode()
+    assert "My RSS post" in content
+    assert "https://blog.abelcastro.dev/my-rss-post/" in content
+    # Tag names are stored lowercase, so the category is rendered lowercase.
+    assert "<category>syndication</category>" in content
+    assert "Draft post" not in content

--- a/app/urls.py
+++ b/app/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 
+from blog.feeds import LatestPostsFeed
 from blog.sitemaps import StaticSitemap
 from blog.views import (
     HomeView,
@@ -74,6 +75,8 @@ urlpatterns = [
     #     name="privacy_policy",
     # ),
     path("robots.txt", robots_txt),
+    # RSS feed
+    path("feed/", cache_page(60 * 60)(LatestPostsFeed()), name="feed"),
     # DISABLED: the redirects are apparently making that google search console
     # is not able to index the new blog
     # path(


### PR DESCRIPTION
## Summary
This PR adds RSS feed functionality to the blog, allowing readers to subscribe to published posts via `/feed/`.

## Key Changes
- **New RSS Feed Implementation** (`app/blog/feeds.py`): Created `LatestPostsFeed` class that:
  - Extends Django's `Feed` class to generate RSS XML
  - Returns the 20 most recent published posts with related tags
  - Converts markdown content to HTML for feed items
  - Includes proper publication dates and post categories (tags)
  - Links to the live blog domain for each post

- **URL Configuration** (`app/urls.py`): 
  - Registered the RSS feed at `/feed/` endpoint
  - Added 1-hour caching to reduce server load

- **Constants** (`app/blog/constants.py`):
  - Extracted `BLOG_TITLE` and `BLOG_DOMAIN` as reusable constants
  - These are used by the feed to generate proper links and metadata

- **Test Coverage** (`app/blog/tests.py`):
  - Added comprehensive test `test__rss_feed()` that verifies:
    - Feed returns correct HTTP status and content type
    - Published posts appear in the feed with correct URLs
    - Post tags are included as RSS categories
    - Draft posts are excluded from the feed

## Implementation Details
- The feed respects the `published` flag, ensuring only published posts are syndicated
- Post tags are automatically included as RSS categories
- Markdown content is converted to HTML using the existing `markdownify` utility
- The feed is cached for 1 hour to optimize performance

https://claude.ai/code/session_01VkUE8LZXfSmHHhMRMahqdV